### PR TITLE
update SwiftyJSON dependency to ~> 2.3.2

### DIFF
--- a/ActionCableClient.podspec
+++ b/ActionCableClient.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
   s.frameworks = 'Foundation'
   s.dependency 'Starscream', '~> 1.1.2'
-  s.dependency 'SwiftyJSON', '~> 2.3.1'
+  s.dependency 'SwiftyJSON', '~> 2.3.2'
 end

--- a/Pod/Classes/JSONSerializer.swift
+++ b/Pod/Classes/JSONSerializer.swift
@@ -116,7 +116,7 @@ internal class JSONSerializer {
             var messageError      : ErrorType?
             
             do {
-                if !JSONObj["message"].isExists() {
+                if !JSONObj["message"].exists() {
                     throw SerializationError.ProtocolViolation
                 }
                 


### PR DESCRIPTION
In SwiftyJSON version 2.3.2 a method isExists() has been changed to exists() which breaks this library.

Here is the relevant change:
https://github.com/SwiftyJSON/SwiftyJSON/commit/5fc4545c7a5d1fd4a2b3d04964f1bc593c356676