### PR TITLE
Crash on 32-bit devices

### DIFF
--- a/Pod/Classes/Channel.swift
+++ b/Pod/Classes/Channel.swift
@@ -179,7 +179,7 @@ open class Channel: Hashable, Equatable {
     internal var onReceiveActionHooks: Dictionary<String, OnReceiveClosure> = Dictionary()
     internal unowned var client: ActionCableClient
     internal var actionBuffer: Array<Action> = Array()
-    open let hashValue: Int = Int(arc4random())
+    open let hashValue: Int = Int(arc4random_uniform(UInt32(Int32.max)))
 }
 
 public func ==(lhs: Channel, rhs: Channel) -> Bool {


### PR DESCRIPTION
Hey!

First of all, thank you for open-sourcing ActionCable library written in Swift! We are just starting to use ActionCable, and it's invaluable to have such library in open-source.

This PR fixes a crash, that happens when creating Channel object on 32-bit devices.

arc4random() method returns UInt32, which on 32 bit devices can be larger than Int.max, and method overflows. I replaced it with arc4random_uniform, restricting it to return random UInt32 value less than Int32.max, thus allowing it to work correctly on both 32 and 64-bit devices.